### PR TITLE
replace Vec arguments with slices

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,5 +41,5 @@ fn main() {
         fileinfo.push(FileInfo { filepath, metadata });
     }
 
-    TableFormat::print_table(fileinfo);
+    TableFormat::print_table(&fileinfo);
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -41,7 +41,7 @@ impl Table {
 
     // We need to find the max length of the filesize and filepath,
     // so that we know how wide to make the table
-    pub fn max_filesize_width(fileinfo: &Vec<FileInfo>) -> usize {
+    pub fn max_filesize_width(fileinfo: &[FileInfo]) -> usize {
         let mut result: usize = 0;
 
         for file in fileinfo {
@@ -55,7 +55,7 @@ impl Table {
         result.separated_string().to_string().len()
     }
 
-    pub fn max_filename_width(fileinfo: &Vec<FileInfo>) -> usize {
+    pub fn max_filename_width(fileinfo: &[FileInfo]) -> usize {
         let mut result: usize = 0;
 
         for file in fileinfo {

--- a/src/table_format.rs
+++ b/src/table_format.rs
@@ -9,16 +9,16 @@ pub struct TableFormat {
 }
 
 impl TableFormat {
-    pub fn print_table(fileinfo: Vec<FileInfo>) {
+    pub fn print_table(fileinfo: &[FileInfo]) {
         let table_widths = TableFormat {
-            filename_width: Table::max_filename_width(&fileinfo),
-            filesize_width: Table::max_filesize_width(&fileinfo),
+            filename_width: Table::max_filename_width(fileinfo),
+            filesize_width: Table::max_filesize_width(fileinfo),
         };
 
         let inner_width = Table::inner_computed_table_width(&table_widths);
 
         Self::print_header(&inner_width, &table_widths);
-        Self::print_body(&fileinfo, &table_widths);
+        Self::print_body(fileinfo, &table_widths);
         Self::print_footer(&inner_width);
     }
 
@@ -42,7 +42,7 @@ impl TableFormat {
         );
     }
 
-    fn print_body(fileinfo: &Vec<FileInfo>, table_widths: &TableFormat) {
+    fn print_body(fileinfo: &[FileInfo], table_widths: &TableFormat) {
         for file in fileinfo {
             println!(
                 "│ {:name$} │ {:>size$} │",


### PR DESCRIPTION
I have replaced the `&Vec<T>` and `Vec<T>` parameters with `&[T]`.

This is done for two reasons:

* `Vec<T>`: `print_table` does not require ownership of the table and thus should not ask for it.
* `&Vec<T>`: it is better to pass a slice than a reference to a vector. See also https://stackoverflow.com/a/24104029