### PR TITLE
Nonstandard chars in filenames are handled correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "separator 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Kieran Eglin <kieran.eglin@gmail.com>"]
 glob = "0.2"
 separator = "0.3.1"
 clap = { version = "2.25.0", features = ["yaml"] }
+unicode-width = "0.1.4"

--- a/src/file_info.rs
+++ b/src/file_info.rs
@@ -1,7 +1,4 @@
 // This file contains functions related to display of file metadata
-
-extern crate separator;
-
 use std::fs::Metadata;
 use std::path::PathBuf;
 use separator::Separatable;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate clap;
 
 extern crate glob;
 extern crate separator;
+extern crate unicode_width;
 
 mod table;
 mod file_info;

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,9 +1,9 @@
 // This file contains functions for calculating table offsets and widths.
-
 use std::cmp::max;
 use file_info::FileInfo;
-use table_format::TableFormat;
 use separator::Separatable;
+use table_format::TableFormat;
+use unicode_width::UnicodeWidthStr;
 
 const HEADER_WIDTH: usize = 8; // 8 happens to be the size of both "Filename" and "Filesize"
 const PADDING_OFFSET: usize = 2; // 2, since there's 1 space on each side of a table element
@@ -18,6 +18,13 @@ impl Table {
         // The table width will be determined here.  If the longest element is
         // shorter than the title, go off the title's width.
         max(HEADER_WIDTH, attribute)
+    }
+
+    pub fn normalized_filename_padding(attribute: usize, file: &FileInfo) -> String {
+        let normalized_padding = Self::attribute_without_padding(attribute) -
+            UnicodeWidthStr::width(file.formatted_filepath().as_str());
+
+        " ".repeat(normalized_padding)
     }
 
     pub fn inner_computed_table_width(table_widths: &TableFormat) -> Self {
@@ -59,7 +66,7 @@ impl Table {
         let mut result: usize = 0;
 
         for file in fileinfo {
-            let width = file.formatted_filepath().len();
+            let width = UnicodeWidthStr::width(file.formatted_filepath().as_str());
 
             if width > result {
                 result = width;

--- a/src/table_format.rs
+++ b/src/table_format.rs
@@ -1,5 +1,4 @@
 // This file contains functions for actually displaying the table
-
 use table::Table;
 use file_info::FileInfo;
 
@@ -44,11 +43,12 @@ impl TableFormat {
 
     fn print_body(fileinfo: &[FileInfo], table_widths: &TableFormat) {
         for file in fileinfo {
+
             println!(
-                "│ {:name$} │ {:>size$} │",
+                "│ {}{name} │ {:>size$} │",
                 file.formatted_filepath(),
                 file.formatted_filesize(),
-                name = Table::attribute_without_padding(table_widths.filename_width),
+                name = Table::normalized_filename_padding(table_widths.filename_width, file),
                 size = Table::attribute_without_padding(table_widths.filesize_width)
             );
         }


### PR DESCRIPTION
Uses [unicode-width](https://crates.io/crates/unicode-width) as suggested by @mbrubeck.  Most non-[a-zA-Z1-9] should be handled correctly now.

Closes #2 